### PR TITLE
Add dashboard page with analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ El código JavaScript se encuentra ahora en `js/index.js` como módulo ES. Aseg�
 ## Despliegue
 
 Se recomienda utilizar una plataforma como Firebase Hosting o GitHub Pages. Para un proceso de despliegue automatizado puedes configurar GitHub Actions.
+
+## Dashboard
+
+La página `dashboard.html` muestra indicadores de ventas y un gráfico mensual.
+Asegúrate de contar con un `js/config.js` válido y abre el archivo en tu navegador (o usa el botón **Dashboard** en la página principal).

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard - Tenis Carmen</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100 font-sans antialiased p-4">
+  <header class="mb-6 flex justify-between items-center">
+    <h1 class="text-2xl font-bold">Dashboard</h1>
+    <a href="index.html" class="text-indigo-600 underline">Volver</a>
+  </header>
+
+  <div id="kpis" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+    <div class="bg-white p-4 rounded shadow text-center">
+      <p class="text-gray-500">Total Ventas</p>
+      <p id="kpi-ventas" class="text-2xl font-bold"></p>
+    </div>
+    <div class="bg-white p-4 rounded shadow text-center">
+      <p class="text-gray-500">Total Abonos</p>
+      <p id="kpi-abonos" class="text-2xl font-bold"></p>
+    </div>
+    <div class="bg-white p-4 rounded shadow text-center">
+      <p class="text-gray-500">Saldo Global</p>
+      <p id="kpi-saldo" class="text-2xl font-bold"></p>
+    </div>
+  </div>
+
+  <div class="bg-white p-4 rounded shadow">
+    <canvas id="ventasChart"></canvas>
+  </div>
+
+  <script type="module" src="js/dashboard.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
                 <div id="user-info" class="mt-4 md:mt-0 text-sm p-2 rounded-lg flex items-center space-x-3 bg-white shadow-sm border">
                     <!-- User info will be injected here -->
                 </div>
+                <a href="dashboard.html" class="mt-4 md:mt-0 bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-lg">Dashboard</a>
             </div>
         </header>
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,0 +1,71 @@
+import { firebaseConfig } from './config.js';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js';
+import {
+  getFirestore,
+  collection,
+  getDocs,
+} from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+  }).format(value);
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const app = initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+
+  const ventasSnap = await getDocs(
+    collection(db, 'negocio-tenis/shared_data/ventas'),
+  );
+  const ventas = ventasSnap.docs.map((doc) => doc.data());
+  const abonosSnap = await getDocs(
+    collection(db, 'negocio-tenis/shared_data/abonos'),
+  );
+  const abonos = abonosSnap.docs.map((doc) => doc.data());
+
+  const totalVentas = ventas.reduce(
+    (sum, v) => sum + (v.precioPactado || 0),
+    0,
+  );
+  const totalAbonos = abonos.reduce((sum, a) => sum + (a.monto || 0), 0);
+  const saldoGlobal = ventas.reduce((sum, v) => sum + (v.saldo || 0), 0);
+
+  document.getElementById('kpi-ventas').textContent =
+    formatCurrency(totalVentas);
+  document.getElementById('kpi-abonos').textContent =
+    formatCurrency(totalAbonos);
+  document.getElementById('kpi-saldo').textContent =
+    formatCurrency(saldoGlobal);
+
+  const monthly = {};
+  ventas.forEach((v) => {
+    if (v.fecha && v.fecha.seconds) {
+      const d = new Date(v.fecha.seconds * 1000);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      monthly[key] = (monthly[key] || 0) + (v.precioPactado || 0);
+    }
+  });
+  const labels = Object.keys(monthly).sort();
+  const data = labels.map((l) => monthly[l]);
+
+  new Chart(document.getElementById('ventasChart').getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Ventas por mes',
+          backgroundColor: '#4f46e5',
+          data,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      scales: { y: { beginAtZero: true } },
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- add new `dashboard.html` and module script
- compute KPIs and monthly sales chart using Firebase
- link dashboard from index page
- document how to open the dashboard

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685da4d2c4108325a2728629b5e759cc