### PR TITLE
Add Chart.js financial dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npx serve .
 
 El código JavaScript se encuentra ahora en `js/index.js` como módulo ES. Asegúrate de mantener tus claves fuera del repositorio creando `js/config.js` (ignorado por git).
 
+La pestaña **Finanzas** ahora incluye indicadores (KPIs) como el número de ventas y el promedio por venta, además de gráficas de ventas y abonos generadas con Chart.js. La biblioteca se carga desde CDN en `index.html`.
+
 ## Despliegue
 
 Se recomienda utilizar una plataforma como Firebase Hosting o GitHub Pages. Para un proceso de despliegue automatizado puedes configurar GitHub Actions.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -327,6 +328,12 @@
                             <div id="caja-actions" class="space-y-4"></div>
                         </div>
                     </div>
+                </div>
+
+                <div id="finanzas-kpis" class="grid grid-cols-1 md:grid-cols-3 gap-6"></div>
+                <div id="finanzas-charts" class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+                    <canvas id="ventasChart"></canvas>
+                    <canvas id="abonosChart"></canvas>
                 </div>
 
             </div>


### PR DESCRIPTION
## Summary
- load Chart.js CDN and provide containers for KPIs and charts
- compute financial KPIs and display charts
- show KPIs and charts when summaries refresh
- document new metrics and dependency

## Testing
- `npm run format` *(restored original files afterward)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685da99d19108325b2f8d19ca6b9ee3a