### PR TITLE
Add searchable multi-item sales with PDF ticket

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,12 +449,18 @@
                         <select id="ventaCliente" class="w-full p-3 border border-gray-300 rounded-lg" required></select>
                     </div>
                     <div>
-                        <label for="ventaTenis" class="block text-sm font-medium text-gray-700 mb-1">Tenis (solo disponibles)</label>
-                        <select id="ventaTenis" class="w-full p-3 border border-gray-300 rounded-lg" required></select>
+                        <label for="productoSearch" class="block text-sm font-medium text-gray-700 mb-1">Buscar Producto</label>
+                        <div class="relative">
+                            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"><i class="fas fa-search"></i></span>
+                            <input type="text" id="productoSearch" placeholder="Marca, modelo, descripción o SKU..." class="w-full p-3 pl-10 pr-10 border border-gray-300 rounded-lg">
+                            <button id="clearSearchProducto" class="search-clear-btn hidden" title="Limpiar búsqueda"><i class="fas fa-times-circle"></i></button>
+                        </div>
+                        <div id="productoResultados" class="max-h-40 overflow-y-auto mt-2 text-sm border border-gray-200 rounded-lg hidden"></div>
                     </div>
-                     <div>
-                        <label for="ventaPrecio" class="block text-sm font-medium text-gray-700 mb-1">Precio final acordado</label>
-                        <input type="number" step="0.01" id="ventaPrecio" placeholder="Precio final acordado" class="w-full p-3 border border-gray-300 rounded-lg" required>
+                    <div id="ventaItemsContainer" class="space-y-2"></div>
+                    <div>
+                        <label for="ventaTotal" class="block text-sm font-medium text-gray-700 mb-1">Total</label>
+                        <input type="number" id="ventaTotal" class="w-full p-3 border border-gray-300 rounded-lg bg-gray-100" readonly>
                     </div>
                 </div>
                 <div class="flex justify-end mt-6 space-x-3">


### PR DESCRIPTION
## Summary
- support searching items in new sale modal
- allow multiple items per sale and calculate total
- generate PDF ticket and share via WhatsApp

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6861823800b08325a661516759546d0d