### PR TITLE
Fix ticket PDF cropping

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1940,11 +1940,19 @@ ${comprasHtml}
       html2canvas: { scale: 2 },
       jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
     };
+
+    const container = document.createElement('div');
+    container.style.position = 'fixed';
+    container.style.left = '-9999px';
+    container.innerHTML = ticketHtml;
+    document.body.appendChild(container);
+
     html2pdf()
-      .from(ticketHtml)
+      .from(container)
       .set(opt)
       .save()
       .then(() => {
+        document.body.removeChild(container);
         const phone = cliente.telefono.replace(/\D/g, '');
         const msg = encodeURIComponent(
           `Gracias por tu compra. Total: ${formatCurrency(total)}.`,


### PR DESCRIPTION
## Summary
- ensure the whole ticket HTML is rendered before PDF generation

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npx prettier --write js/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6861ce64a4f08325956fe85807753786