### PR TITLE
Improve PDF generation reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ El código JavaScript se encuentra ahora en `js/index.js` como módulo ES. Aseg�
 ## Despliegue
 
 Se recomienda utilizar una plataforma como Firebase Hosting o GitHub Pages. Para un proceso de despliegue automatizado puedes configurar GitHub Actions.
+
+## Solución de Problemas
+
+Si al generar el ticket de venta el PDF aparece en blanco:
+
+1. Verifica que abras la aplicación desde un servidor local y no directamente con `file://`. Puedes usar `npx serve .` o la extensión *Live Server*.
+2. Asegúrate de que las librerías externas se cargaron correctamente antes de generar el ticket.

--- a/js/index.js
+++ b/js/index.js
@@ -1881,7 +1881,7 @@ ${comprasHtml}
       margin: 1,
       filename: `Estado_de_Cuenta_${cliente.nombre.replace(/\s/g, '_')}.pdf`,
       image: { type: 'jpeg', quality: 0.98 },
-      html2canvas: { scale: 2 },
+      html2canvas: { scale: 2, useCORS: true },
       jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
     };
     html2pdf().from(reportHtml).set(opt).save();
@@ -1937,7 +1937,7 @@ ${comprasHtml}
       margin: 0.5,
       filename: `Ticket_${cliente.nombre.replace(/\s/g, '_')}.pdf`,
       image: { type: 'jpeg', quality: 0.98 },
-      html2canvas: { scale: 2 },
+      html2canvas: { scale: 2, useCORS: true },
       jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
     };
 


### PR DESCRIPTION
## Summary
- improve PDF generation by enabling CORS on html2canvas
- document troubleshooting steps for blank PDF tickets

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6861ddbf1aa08325b8b09e863af15bf1