### PR TITLE
Fix blank PDF for sales tickets

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1005,7 +1005,9 @@ ${obsHtml}
       .forEach((btn) => btn.addEventListener('click', handleEditVenta));
     document
       .querySelectorAll('.ticketVentaBtn')
-      .forEach((btn) => btn.addEventListener('click', handleGenerateVentaTicket));
+      .forEach((btn) =>
+        btn.addEventListener('click', handleGenerateVentaTicket),
+      );
     document
       .querySelectorAll('.whatsappVentaBtn')
       .forEach((btn) => btn.addEventListener('click', handleSendVentaWhatsapp));
@@ -1620,9 +1622,7 @@ ${obsHtml}
     const detalles = grupo
       .map((v) => {
         const prod = allInventario[v.tenisId];
-        const desc = prod
-          ? `${prod.marca} ${prod.modelo}`
-          : v.tenisId;
+        const desc = prod ? `${prod.marca} ${prod.modelo}` : v.tenisId;
         return `- ${desc}: ${formatCurrency(v.precioPactado)}`;
       })
       .join('\n');
@@ -1996,19 +1996,7 @@ ${comprasHtml}
       jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
     };
 
-    const container = document.createElement('div');
-    container.style.position = 'fixed';
-    container.style.left = '-9999px';
-    container.innerHTML = ticketHtml;
-    document.body.appendChild(container);
-
-    html2pdf()
-      .from(container)
-      .set(opt)
-      .save()
-      .then(() => {
-        document.body.removeChild(container);
-      });
+    html2pdf().from(ticketHtml).set(opt).save();
   }
 
   // --- APP INITIALIZATION ---


### PR DESCRIPTION
## Summary
- prevent empty PDF by passing the generated HTML directly to html2pdf

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6862c00e7f908325b4069ae6d1e437a0