### PR TITLE
Add inventory PDF catalog generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,9 +169,14 @@
                         <input type="text" id="searchInventario" placeholder="Buscar por modelo, marca o SKU..." class="w-full p-3 pl-10 pr-10 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
                         <button id="clearSearchInventario" class="search-clear-btn hidden" title="Limpiar búsqueda"><i class="fas fa-times-circle"></i></button>
                     </div>
-                    <button id="openInventarioModalBtn" class="w-full md:w-auto bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-5 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex-shrink-0">
-                        <i class="fas fa-plus mr-2"></i>Agregar Producto
-                    </button>
+                    <div class="flex gap-2 w-full md:w-auto">
+                        <button id="openInventarioModalBtn" class="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-5 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex-shrink-0">
+                            <i class="fas fa-plus mr-2"></i>Agregar Producto
+                        </button>
+                        <button id="downloadCatalogBtn" class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-3 px-5 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex-shrink-0">
+                            <i class="fas fa-file-pdf mr-2"></i>Catálogo PDF
+                        </button>
+                    </div>
                 </div>
 
                 <div class="bg-indigo-600 text-white p-4 rounded-xl shadow-lg flex justify-between items-center">


### PR DESCRIPTION
## Summary
- add a **Catálogo PDF** button in the Inventario section
- implement `generateCatalogPDF` and a handler to build a PDF with all available products grouped by categoría and género

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6862d90160e883259773b4af9fa64707