### PR TITLE
Implement DB backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ El código JavaScript se encuentra ahora en `js/index.js` como módulo ES.
 ## Despliegue
 
 Se recomienda utilizar una plataforma como Firebase Hosting o GitHub Pages. Para un proceso de despliegue automatizado puedes configurar GitHub Actions.
+
+## Respaldo y Restauración
+
+En la sección de Finanzas encontrarás los botones **Respaldar Base de Datos** y **Restaurar Base de Datos**.
+
+* **Respaldar Base de Datos** descarga un archivo JSON con los documentos de las colecciones `clientes`, `inventario`, `ventas`, `abonos` y `cortes`.
+* **Restaurar Base de Datos** permite seleccionar un archivo generado por el respaldo e insertarlo de nuevo en Firestore. Se mostrará una confirmación antes de sobrescribir la información existente.
+
+Es necesario haber iniciado sesión con una cuenta autorizada para realizar estas operaciones. Ten en cuenta que el respaldo solo incluye los documentos de Firestore; no contiene configuraciones de índices ni información de autenticación de Firebase.

--- a/index.html
+++ b/index.html
@@ -348,6 +348,9 @@
                                 <button id="exportInventarioBtn" class="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg"><i class="fas fa-box-open mr-2"></i>Inventario</button>
                                 <button id="exportVentasBtn" class="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-lg"><i class="fas fa-shopping-cart mr-2"></i>Ventas</button>
                                 <button id="exportAbonosBtn" class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg"><i class="fas fa-coins mr-2"></i>Abonos</button>
+                                <button id="backupDbBtn" class="w-full bg-amber-600 hover:bg-amber-700 text-white font-bold py-2 px-4 rounded-lg"><i class="fas fa-database mr-2"></i>Respaldar Base de Datos</button>
+                                <button id="restoreDbBtn" class="w-full bg-amber-700 hover:bg-amber-800 text-white font-bold py-2 px-4 rounded-lg"><i class="fas fa-upload mr-2"></i>Restaurar Base de Datos</button>
+                                <input type="file" id="restoreFileInput" accept="application/json" class="hidden">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- add helpers `backupDatabase` and `restoreDatabase`
- hook backup/restore buttons in the UI
- add buttons to **Finanzas** panel
- document usage in README

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68641df30fa88325a27914af68bb140b