### PR TITLE
Enable long polling Firestore

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -11,7 +11,7 @@ import {
   signInWithPopup,
 } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js';
 import {
-  getFirestore,
+  initializeFirestore,
   collection,
   doc,
   addDoc,
@@ -34,7 +34,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // --- FIREBASE INITIALIZATION ---
   const app = initializeApp(firebaseConfig);
-  const db = getFirestore(app);
+  const db = initializeFirestore(app, {
+    experimentalAutoDetectLongPolling: true,
+  });
   const auth = getAuth(app);
   const provider = new GoogleAuthProvider();
   let unsubscribeListeners = [];

--- a/js/public.js
+++ b/js/public.js
@@ -1,7 +1,7 @@
 import { firebaseConfig } from './config.js';
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js';
 import {
-  getFirestore,
+  initializeFirestore,
   collection,
   onSnapshot,
   query,
@@ -14,7 +14,9 @@ import {
 } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js';
 
 const app = initializeApp(firebaseConfig);
-const db = getFirestore(app);
+const db = initializeFirestore(app, {
+  experimentalAutoDetectLongPolling: true,
+});
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider();
 


### PR DESCRIPTION
## Summary
- initialize Firestore with experimental long polling in `public.js`
- use the same initialization in `index.js`

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68659630dcac83259114f9f176146054