### PR TITLE
Replace snapshot with one-time product fetch

### DIFF
--- a/js/public.js
+++ b/js/public.js
@@ -3,7 +3,7 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebas
 import {
   initializeFirestore,
   collection,
-  onSnapshot,
+  getDocs,
   query,
   where,
 } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
@@ -64,22 +64,20 @@ function loadInventory() {
     collection(db, 'negocio-tenis/shared_data/inventario'),
     where('status', '==', 'disponible'),
   );
-  onSnapshot(
-    q,
-    (snap) => {
+  getDocs(q)
+    .then((snap) => {
       allProducts = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
       localStorage.setItem(INVENTORY_CACHE_KEY, JSON.stringify(allProducts));
       renderFilters(allProducts);
       applyFilters();
-    },
-    (err) => {
+    })
+    .catch((err) => {
       console.error('Error cargando productos', err);
       if (!cached) {
         container.innerHTML =
           '<p class="col-span-full text-center text-gray-500">Error cargando productos</p>';
       }
-    },
-  );
+    });
 }
 
 function renderFilters(products) {


### PR DESCRIPTION
## Summary
- convert public product loader from `onSnapshot` to single `getDocs` call

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68659c22df0c8325a1bb1438faa68b07