### PR TITLE
Fix empty PDF export

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -2152,8 +2152,13 @@ ${comprasHtml}
       html2canvas: { scale: 2, useCORS: true },
       jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
     };
-
-    html2pdf().from(ticketHtml).set(opt).save();
+    const container = document.createElement('div');
+    container.innerHTML = ticketHtml;
+    html2pdf()
+      .from(container)
+      .set(opt)
+      .save()
+      .then(() => container.remove());
   }
 
   function generateCatalogPDF() {


### PR DESCRIPTION
## Summary
- generate PDF from temporary DOM element to avoid blank PDFs

## Testing
- `npm run lint` *(fails: config not supported)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68671a3a6ce08325a6ce4e3004260762