### PR TITLE
Replace html2pdf with pdfmake

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -17,7 +17,9 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html-to-pdfmake/2.1.2/html-to-pdfmake.min.js"></script>
     <style>
       body {
         font-family: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- load pdfmake and html-to-pdfmake in `admin.html`
- add helper to convert HTML to pdfmake and generate PDFs
- switch account report, sales ticket and catalog exports to pdfmake

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68672629abc88325b80a7048e4d80525