### PR TITLE
Fix colspan in client info table

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -2117,7 +2117,7 @@ ${
   cliente.observaciones
     ? `
 <tr>
-<td colspan="3" style="padding: 10px; font-size: 0.88rem; color: #4b5563; background-color: #f9fafb;">
+<td colspan="2" style="padding: 10px; font-size: 0.88rem; color: #4b5563; background-color: #f9fafb;">
 <strong>Observaciones:</strong> ${cliente.observaciones}
 </td>
 </tr>`


### PR DESCRIPTION
## Summary
- fix colspan attribute for client observations row to match column count

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68673972bef08325917fdd4c53101f2c