### PR TITLE
Fix NaN error in pdf generation

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -239,6 +239,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         /([\d.]+)em/g,
         (_, n) => `${parseFloat(n) * 16}px`,
       );
+      cleaned = cleaned.replace(
+        /([\d.]+)in/g,
+        (_, n) => `${parseFloat(n) * 96}px`,
+      );
       if (cleaned.trim()) {
         el.setAttribute('style', cleaned);
       } else {


### PR DESCRIPTION
## Summary
- fix inch unit conversion in pdf generation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867425a3944832581865865780459ae