### PR TITLE
Fix pdf generation error by cleaning CSS styles

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,24 @@ export default [
   {
     languageOptions: {
       ecmaVersion: 12,
-      sourceType: 'module'
+      sourceType: 'module',
+      globals: {
+        document: 'readonly',
+        window: 'readonly',
+        console: 'readonly',
+        setTimeout: 'readonly',
+        Intl: 'readonly',
+        Blob: 'readonly',
+        FileReader: 'readonly',
+        DOMParser: 'readonly',
+        fetch: 'readonly',
+        Event: 'readonly',
+        URL: 'readonly',
+        localStorage: 'readonly',
+        alert: 'readonly',
+        pdfMake: 'readonly',
+        htmlToPdfmake: 'readonly'
+      }
     },
     rules: {}
   }

--- a/js/index.js
+++ b/js/index.js
@@ -243,6 +243,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         /([\d.]+)in/g,
         (_, n) => `${parseFloat(n) * 96}px`,
       );
+      cleaned = cleaned.replace(/:\s*auto\b/g, ':0');
       if (cleaned.trim()) {
         el.setAttribute('style', cleaned);
       } else {
@@ -707,7 +708,6 @@ Realizar Corte Z
     const ventasLiquidadas = [];
 
     for (const ventaId in ventasAfectadas) {
-      const info = ventasAfectadas[ventaId];
       const ventaOriginal = localVentas.find((v) => v.id === ventaId);
       const saldoPostAbonos = ventaOriginal.saldo; // Saldo ya actualizado por los abonos
 
@@ -1900,8 +1900,7 @@ ${obsHtml}
 
   async function generateCobranzaMessage(
     cliente,
-    ventas,
-    tono = 'amable y profesional',
+    ventas
   ) {
     if (geminiApiKey === 'TU_API_KEY_AQUÍ' || !geminiApiKey) {
       showAlert(


### PR DESCRIPTION
## Summary
- prevent `margin:auto` from breaking pdfmake
- silence ESLint by declaring browser globals
- remove unused variables to pass lint

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686748ce452c8325a56a6f08e0849247