### PR TITLE
Fix image load errors when generating PDFs

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -220,20 +220,20 @@ document.addEventListener('DOMContentLoaded', async () => {
       );
     };
     reader.readAsText(file);
+  };
 
-    const fetchImageWithProxy = async (url) => {
-      const attempt = async (u) => {
-        const res = await fetch(u);
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.blob();
-      };
-      try {
-        return await attempt(url);
-      } catch (err) {
-        console.warn('Retrying via CORS proxy:', url, err);
-        return attempt(`https://corsproxy.io/?${encodeURIComponent(url)}`);
-      }
+  const fetchImageWithProxy = async (url) => {
+    const attempt = async (u) => {
+      const res = await fetch(u);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.blob();
     };
+    try {
+      return await attempt(url);
+    } catch (err) {
+      console.warn('Retrying via CORS proxy:', url, err);
+      return attempt(`https://corsproxy.io/?${encodeURIComponent(url)}`);
+    }
   };
 
   const convertImagesToDataUrls = async (html) => {


### PR DESCRIPTION
## Summary
- make `fetchImageWithProxy` available globally

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686758f897048325aaf0665fe1789ac1