### PR TITLE
Handle invalid image responses

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -225,7 +225,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   const fetchImageWithProxy = async (url) => {
     const attempt = async (u) => {
       const res = await fetch(u);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const type = res.headers.get('content-type') || '';
+      if (!res.ok || !type.startsWith('image/')) {
+        throw new Error(`Invalid image response: HTTP ${res.status} ${type}`);
+      }
       return res.blob();
     };
     try {


### PR DESCRIPTION
## Summary
- add content-type validation in `fetchImageWithProxy`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68675a880e908325a9987ef3d3402188