### PR TITLE
Add AllOrigins proxy fallback for image fetch

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -230,12 +230,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         throw new Error(`Invalid image response: HTTP ${res.status} ${type}`);
       }
       return res.blob();
-  };
-  const proxies = [
-    url,
-    `https://corsproxy.io/?${encodeURIComponent(url)}`,
-    `https://images.weserv.nl/?url=${url.replace(/^https?:\/\//, '')}`,
-  ];
+    };
+    const proxies = [
+      url,
+      `https://corsproxy.io/?${encodeURIComponent(url)}`,
+      `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+      `https://images.weserv.nl/?url=${url.replace(/^https?:\/\//, '')}`,
+    ];
     for (const p of proxies) {
       try {
         return await attempt(p);


### PR DESCRIPTION
## Summary
- improve CORS handling by trying AllOrigins proxy when loading images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68675f5bc53083258276aff6492422fe