### PR TITLE
Add product info overlay to carousel

### DIFF
--- a/js/public.js
+++ b/js/public.js
@@ -145,11 +145,26 @@ function renderCarousel(products) {
   }
   container.classList.remove('hidden');
   valid.forEach((p) => {
+    const slide = document.createElement('div');
+    slide.className = 'relative w-full h-60 flex-shrink-0';
+
     const img = document.createElement('img');
     img.src = p.foto;
     img.alt = p.modelo;
-    img.className = 'w-full h-60 object-cover flex-shrink-0';
-    slides.appendChild(img);
+    img.className = 'w-full h-full object-cover';
+    slide.appendChild(img);
+
+    const info = document.createElement('div');
+    info.className =
+      'absolute bottom-0 left-0 right-0 bg-black bg-opacity-50 text-white text-xs p-1';
+    const price = formatCurrency(p.precioOferta ?? p.precio);
+    info.innerHTML = `
+      <p><strong>${p.marca}</strong> ${p.modelo}</p>
+      <p>SKU: ${p.sku || 'N/A'} | Talla: ${p.talla} | Género: ${p.genero || 'N/A'} | Precio: ${price}</p>
+    `;
+    slide.appendChild(info);
+
+    slides.appendChild(slide);
   });
   let index = 0;
   function update() {


### PR DESCRIPTION
## Summary
- show product info on carousel slides so users can see details at a glance

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686824f8bd2c83258e7fdc4d3974ef67