### PR TITLE
Add manual public inventory update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ El script `export-inventory` genera un archivo `inventory.json` con los producto
 npm run export-inventory -- path/to/serviceAccount.json
 ```
 
+En producción se puede generar automáticamente mediante una **Cloud Function**.
+Además, en la sección **Finanzas** existe el botón **Actualizar Inventario
+Público** que invoca dicha función manualmente.
+

--- a/admin.html
+++ b/admin.html
@@ -673,6 +673,12 @@
                     <i class="fas fa-coins mr-2"></i>Abonos
                   </button>
                   <button
+                    id="updatePublicInventoryBtn"
+                    class="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-4 rounded-lg"
+                  >
+                    <i class="fas fa-sync-alt mr-2"></i>Actualizar Inventario Público
+                  </button>
+                  <button
                     id="backupDbBtn"
                     class="w-full bg-amber-600 hover:bg-amber-700 text-white font-bold py-2 px-4 rounded-lg"
                   >

--- a/js/config.js
+++ b/js/config.js
@@ -9,3 +9,7 @@ export const firebaseConfig = {
 };
 
 export const geminiApiKey = "AIzaSyDlYPXBYtJQ_CNGcuijTdX9yIpBZdoepD4";
+
+// URL de la Cloud Function que genera `inventory.json`
+export const inventoryExportEndpoint =
+  "https://us-central1-tenis-1baf2.cloudfunctions.net/exportInventory";

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,9 @@
 // Firebase Imports
-import { firebaseConfig, geminiApiKey } from './config.js';
+import {
+  firebaseConfig,
+  geminiApiKey,
+  inventoryExportEndpoint,
+} from './config.js';
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js';
 import {
   getAuth,
@@ -220,6 +224,25 @@ document.addEventListener('DOMContentLoaded', async () => {
       );
     };
     reader.readAsText(file);
+  };
+
+  const updatePublicInventory = async () => {
+    try {
+      const res = await fetch(inventoryExportEndpoint, { method: 'POST' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      showAlert(
+        'Inventario Actualizado',
+        'Se generó el archivo público de inventario.',
+        'success',
+      );
+    } catch (error) {
+      console.error('Error updating public inventory:', error);
+      showAlert(
+        'Error',
+        'No se pudo actualizar el inventario público.',
+        'error',
+      );
+    }
   };
 
   const fetchImageWithProxy = async (url) => {
@@ -2892,6 +2915,9 @@ ${comprasHtml}
       .addEventListener('click', () =>
         exportArrayToCSV(allAbonos, 'abonos.csv'),
       );
+    document
+      .getElementById('updatePublicInventoryBtn')
+      .addEventListener('click', updatePublicInventory);
     document
       .getElementById('backupDbBtn')
       .addEventListener('click', backupDatabase);


### PR DESCRIPTION
## Summary
- add button "Actualizar Inventario Público" in the Finanzas section
- add `inventoryExportEndpoint` config constant
- implement `updatePublicInventory()` and event listener
- document how the new button works

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686848e02b688325be672b2c1dc5408f