### PR TITLE
Fix modal overflow on mobile

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -35,6 +35,8 @@
       }
       .modal-content {
         transition: transform 0.3s ease;
+        max-height: 90vh;
+        overflow-y: auto;
       }
       .search-clear-btn {
         position: absolute;


### PR DESCRIPTION
## Summary
- prevent modal height overflow on mobile by adding a max height

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68689c2f660c8325bb40474ad77f6698