### PR TITLE
Enable local photo uploads

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -818,18 +818,25 @@
                   ✨ Generar con IA
                 </button>
               </div>
-              <textarea
-                id="inventarioDescripcion"
-                placeholder="Descripción atractiva del producto..."
-                class="w-full p-3 border border-gray-300 rounded-lg"
-                rows="3"
-              ></textarea>
-            </div>
-            <input
-              type="text"
-              id="inventarioFoto"
-              placeholder="URL de la foto (ej. https://.../foto.jpg)"
+            <textarea
+              id="inventarioDescripcion"
+              placeholder="Descripción atractiva del producto..."
               class="w-full p-3 border border-gray-300 rounded-lg"
+              rows="3"
+            ></textarea>
+          </div>
+          <input
+            type="file"
+            id="inventarioFotoFile"
+            accept="image/*"
+            capture="environment"
+            class="w-full p-3 border border-gray-300 rounded-lg"
+          />
+          <input
+            type="text"
+            id="inventarioFoto"
+            placeholder="URL de la foto (ej. https://.../foto.jpg)"
+            class="w-full p-3 border border-gray-300 rounded-lg"
             />
             <div class="flex space-x-4">
               <input

--- a/js/index.js
+++ b/js/index.js
@@ -30,6 +30,12 @@ import {
   Timestamp,
   updateDoc,
 } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
+import {
+  getStorage,
+  ref as storageRef,
+  uploadBytes,
+  getDownloadURL,
+} from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const loadStartTimestamp = Date.now();
@@ -42,6 +48,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     experimentalAutoDetectLongPolling: true,
   });
   const auth = getAuth(app);
+  const storage = getStorage(app);
   const provider = new GoogleAuthProvider();
   let unsubscribeListeners = [];
 
@@ -2473,6 +2480,25 @@ ${comprasHtml}
         document.getElementById('endDate').value = '';
         renderFinancialSummaries();
       });
+
+    document
+      .getElementById('inventarioFotoFile')
+      .addEventListener('change', handleFotoUpload);
+
+    async function handleFotoUpload(e) {
+      const file = e.target.files[0];
+      if (!file) return;
+      const path = `inventario/${Date.now()}_${file.name}`;
+      try {
+        const ref = storageRef(storage, path);
+        await uploadBytes(ref, file);
+        const url = await getDownloadURL(ref);
+        document.getElementById('inventarioFoto').value = url;
+      } catch (err) {
+        console.error('Error uploading image: ', err);
+        showAlert('Error', 'No se pudo subir la imagen.', 'error');
+      }
+    }
 
     // Form and Modal Listeners
     document


### PR DESCRIPTION
## Summary
- allow selecting or capturing an image when creating or editing inventory items
- upload selected photo to Firebase Storage and store its URL

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68689fe46e6483259224f6d6abda94d4