### PR TITLE
Fix model number field visibility

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -729,7 +729,6 @@
                 class="w-full p-3 border border-gray-300 rounded-lg uppercase"
                 required
               />
-              <datalist id="marcasList"></datalist>
               <input
                 type="text"
                 id="inventarioModelo"
@@ -744,6 +743,7 @@
                 class="w-full p-3 border border-gray-300 rounded-lg uppercase"
               />
             </div>
+            <datalist id="marcasList"></datalist>
             <input
               type="text"
               id="inventarioSku"


### PR DESCRIPTION
## Summary
- ensure the product "Nº de Modelo" input is visible by moving the `marcasList` datalist out of the grid

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686958a559c48325b88a48b9f2ea6b3d