### PR TITLE
Fix iOS image picker

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -827,7 +827,6 @@
             type="file"
             id="inventarioFotoFile"
             accept="image/*"
-            capture="environment"
             class="w-full p-3 border border-gray-300 rounded-lg"
           />
             <div class="flex space-x-4">


### PR DESCRIPTION
## Summary
- remove the `capture` attribute from the product photo input so iOS can select from the photo library

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686961e7959c8325b3b4b736f33209b3