### PR TITLE
Fix catalog pdf margins

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -363,6 +363,24 @@ document.addEventListener('DOMContentLoaded', async () => {
   ) => {
     const processedHtml = await convertImagesToDataUrls(html);
     const pdfContent = htmlToPdfmake(processedHtml, { window });
+    const applyUnbreakable = (node) => {
+      if (Array.isArray(node)) {
+        node.forEach(applyUnbreakable);
+        return;
+      }
+      if (!node || typeof node !== 'object') return;
+      if (node.pageBreakInside === 'avoid') {
+        node.unbreakable = true;
+      }
+      if (node.stack) applyUnbreakable(node.stack);
+      if (node.ul) applyUnbreakable(node.ul);
+      if (node.ol) applyUnbreakable(node.ol);
+      if (node.table && node.table.body) {
+        node.table.body.forEach(applyUnbreakable);
+      }
+      if (node.columns) applyUnbreakable(node.columns);
+    };
+    applyUnbreakable(pdfContent);
     let header = undefined;
     if (headerHtml) {
       const processedHeader = await convertImagesToDataUrls(headerHtml);
@@ -370,6 +388,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     const docDefinition = {
       pageOrientation: orientation,
+      pageMargins: [40, 120, 40, 60],
       content: pdfContent,
     };
     if (header) {


### PR DESCRIPTION
## Summary
- adjust downloadPdfFromHtml helper to set larger page margins
- mark elements with `page-break-inside:avoid` as unbreakable before generating the pdf
- apply same fix in public catalog logic

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686993bf45288325a90d8b62741f02ef