### PR TITLE
Add carousel autoplay and inventory lightbox

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1375,6 +1375,13 @@
     </div>
 
     <div
+      id="imageModal"
+      class="modal fixed inset-0 bg-black bg-opacity-75 hidden flex items-center justify-center p-4 z-50"
+    >
+      <img src="" alt="Vista ampliada" class="max-w-full max-h-full rounded-lg shadow-xl" />
+    </div>
+
+    <div
       id="alertModal"
       class="modal fixed inset-0 bg-gray-900 bg-opacity-50 hidden items-center justify-center p-4 z-50"
     >

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
         window: 'readonly',
         console: 'readonly',
         setTimeout: 'readonly',
+        setInterval: 'readonly',
         Intl: 'readonly',
         Blob: 'readonly',
         FileReader: 'readonly',

--- a/js/index.js
+++ b/js/index.js
@@ -1101,7 +1101,7 @@ ${Object.entries(comisionesPorVendedor)
           : `<button class="editInventarioBtn text-sm text-gray-500 hover:text-indigo-600 flex items-center justify-center p-2 rounded-lg hover:bg-gray-100" data-id="${item.id}" title="Editar"><i class="fas fa-edit fa-lg"></i></button>`;
 
       card.innerHTML = `${ribbon}
-<img src="${item.foto || 'tenis_default.jpg'}" alt="${item.modelo}" class="w-full sm:w-24 h-24 object-cover rounded-lg flex-shrink-0" onerror="this.onerror=null;this.src='https://placehold.co/96x96/e2e8f0/64748b?text=N/A';">
+<img src="${item.foto || 'tenis_default.jpg'}" data-full="${item.foto || 'tenis_default.jpg'}" alt="${item.modelo}" class="product-img w-full sm:w-24 h-24 object-cover rounded-lg flex-shrink-0 cursor-pointer" onerror="this.onerror=null;this.src='https://placehold.co/96x96/e2e8f0/64748b?text=N/A';">
 <div class="flex-grow">
 <div class="flex justify-between items-start">
 <h4 class="font-bold text-lg text-gray-900">${item.marca} - ${item.modelo}</h4>
@@ -1135,9 +1135,19 @@ ${editButtonHtml}
     document
       .querySelectorAll('.editInventarioBtn')
       .forEach((btn) => btn.addEventListener('click', handleEditInventario));
-    document
+  document
       .querySelectorAll('.deleteInventarioBtn')
       .forEach((btn) => btn.addEventListener('click', handleDeleteInventario));
+
+    document
+      .querySelectorAll('.product-img')
+      .forEach((img) =>
+        img.addEventListener('click', () => {
+          const modal = document.getElementById('imageModal');
+          modal.querySelector('img').src = img.dataset.full;
+          showModal(modal);
+        }),
+      );
   }
 
   function renderClientes(clientes, searchTerm = '') {

--- a/js/public.js
+++ b/js/public.js
@@ -193,6 +193,10 @@ function renderCarousel(products) {
     index = (index + 1) % valid.length;
     update();
   };
+  setInterval(() => {
+    index = (index + 1) % valid.length;
+    update();
+  }, 3000);
   update();
 }
 


### PR DESCRIPTION
## Summary
- auto-advance carousel every 3 seconds
- allow inventory images to open in a modal lightbox
- include new modal markup for inventory images
- update ESLint globals

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686afea2e0cc83259a65dcea093e095d