### PR TITLE
Reduce TTL for public inventory

### DIFF
--- a/js/public.js
+++ b/js/public.js
@@ -37,7 +37,8 @@ document.getElementById('sortSelect').value = sortOrder;
 
 const INVENTORY_CACHE_KEY = 'inventoryCache';
 const INVENTORY_CACHE_TS_KEY = 'inventoryCacheTime';
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
+// Reduce cache TTL so public inventory refreshes quickly
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 function showSkeleton(count = 8) {
   const container = document.getElementById('productsContainer');


### PR DESCRIPTION
## Summary
- cache public inventory for 5 minutes instead of 24 hours

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b2af3eb0883258c8e9ecedc4e1c76