### PR TITLE
Add coverflow effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,23 @@
         border-radius: 0.375rem;
         height: 0.75rem;
       }
+      /* Coverflow carousel styles */
+      #carouselContainer {
+        perspective: 1000px;
+      }
+      #carouselSlides {
+        display: flex;
+        justify-content: center;
+        position: relative;
+        transform-style: preserve-3d;
+      }
+      .cover-slide {
+        transition: transform 0.5s, opacity 0.5s;
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform-origin: center center;
+      }
     </style>
   </head>
   <body class="font-[Inter] bg-gray-100 text-gray-800">
@@ -106,11 +123,11 @@
       </div>
       <div
         id="carouselContainer"
-        class="relative w-full overflow-hidden mb-4 hidden"
+        class="relative w-full h-60 overflow-hidden mb-4 hidden"
       >
         <div
           id="carouselSlides"
-          class="flex transition-transform duration-500"
+          class="relative h-full w-full"
         ></div>
         <button
           id="carouselPrev"

--- a/js/public.js
+++ b/js/public.js
@@ -162,7 +162,7 @@ function renderCarousel(products) {
   container.classList.remove('hidden');
   valid.forEach((p) => {
     const slide = document.createElement('div');
-    slide.className = 'relative w-full h-60 flex-shrink-0';
+    slide.className = 'cover-slide w-3/4 sm:w-1/2 h-full';
 
     const img = document.createElement('img');
     img.src = p.foto;
@@ -184,7 +184,19 @@ function renderCarousel(products) {
   });
   let index = 0;
   function update() {
-    slides.style.transform = `translateX(-${index * 100}%)`;
+    const elems = slides.children;
+    for (let i = 0; i < elems.length; i++) {
+      const offset = i - index;
+      const abs = Math.abs(offset);
+      const rotate = offset * -45;
+      const translate = offset * 60;
+      const scale = offset === 0 ? 1 : 0.7;
+      const z = 100 - abs;
+      elems[i].style.transform =
+        `translateX(${translate}%) rotateY(${rotate}deg) scale(${scale})`;
+      elems[i].style.zIndex = z;
+      elems[i].style.opacity = abs > 3 ? 0 : 1;
+    }
   }
   document.getElementById('carouselPrev').onclick = () => {
     index = (index - 1 + valid.length) % valid.length;


### PR DESCRIPTION
## Summary
- enable coverflow-style animations in the public carousel
- tweak carousel container markup and styles

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686be85b24c08325b71c183984bdb5dd