### PR TITLE
Fix carousel centering

### DIFF
--- a/js/public.js
+++ b/js/public.js
@@ -193,7 +193,7 @@ function renderCarousel(products) {
       const scale = offset === 0 ? 1 : 0.7;
       const z = 100 - abs;
       elems[i].style.transform =
-        `translateX(${translate}%) rotateY(${rotate}deg) scale(${scale})`;
+        `translateX(-50%) translateX(${translate}%) rotateY(${rotate}deg) scale(${scale})`;
       elems[i].style.zIndex = z;
       elems[i].style.opacity = abs > 3 ? 0 : 1;
     }


### PR DESCRIPTION
## Summary
- ensure carousel slides are centered by default

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686beb5b5b3c832583f90dde926f815b