### PR TITLE
Add Google Images search button

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -827,6 +827,13 @@
           <p class="text-sm text-gray-600">
             La foto del producto se asigna automáticamente según el SKU. Puedes copiar o editar el enlace.
           </p>
+          <button
+            type="button"
+            id="searchImageBtn"
+            class="text-xs bg-indigo-100 text-indigo-700 font-semibold px-2 py-1 rounded-md hover:bg-indigo-200 mb-2"
+          >
+            🔍 Buscar Imagen
+          </button>
           <input
             type="text"
             id="inventarioFoto"

--- a/js/index.js
+++ b/js/index.js
@@ -3105,6 +3105,21 @@ ${comprasHtml}
     document
       .getElementById('generateDescBtn')
       .addEventListener('click', generateProductDescription);
+    document
+      .getElementById('searchImageBtn')
+      .addEventListener('click', () => {
+        const numModelo = document.getElementById('inventarioNumeroModelo').value;
+        if (numModelo) {
+          const query = encodeURIComponent(numModelo);
+          window.open(`https://www.google.com/search?tbm=isch&q=${query}`, '_blank');
+        } else {
+          showAlert(
+            'Número de Modelo vacío',
+            'Ingresa un número de modelo para buscar imágenes.',
+            'info',
+          );
+        }
+      });
     skuInput.addEventListener('input', updateFotoLink);
     document
       .getElementById('productoSearch')


### PR DESCRIPTION
## Summary
- add a button in the inventory modal to quickly search Google Images for the model number
- wire up event handler to open Google images search

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687807da84a88325b56ab06034e492ab