### PR TITLE
Enforce product photo aspect ratio

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1116,7 +1116,7 @@ ${Object.entries(comisionesPorVendedor)
 
       card.innerHTML = `<div class="relative flex-shrink-0">
   ${ribbon}
-  <img src="${item.foto || 'tenis_default.jpg'}" data-full="${item.foto || 'tenis_default.jpg'}" alt="${item.modelo}" class="product-img w-full sm:w-24 h-24 object-cover rounded-lg cursor-pointer" onerror="this.onerror=null;this.src='https://placehold.co/96x96/e2e8f0/64748b?text=N/A';">
+  <img src="${item.foto || 'tenis_default.jpg'}" data-full="${item.foto || 'tenis_default.jpg'}" alt="${item.modelo}" class="product-img w-full sm:w-24 aspect-[3/4] object-cover rounded-lg cursor-pointer" onerror="this.onerror=null;this.src='https://placehold.co/96x96/e2e8f0/64748b?text=N/A';">
 </div>
   <div class="flex-grow">
 <div class="flex justify-between items-start">

--- a/js/public.js
+++ b/js/public.js
@@ -48,7 +48,7 @@ function showSkeleton(count = 8) {
     card.className =
       'skeleton-card space-y-2 p-4 rounded-xl shadow animate-pulse';
     card.innerHTML = `
-      <div class="h-40 w-full"></div>
+      <div class="w-full aspect-[3/4]"></div>
       <div class="h-4 w-3/4"></div>
       <div class="h-4 w-1/2"></div>
     `;
@@ -253,7 +253,7 @@ function renderProducts(products) {
       ${ribbon}
       <img src="${
         p.foto || 'tenis_default.jpg'
-      }" data-full="${p.foto || 'tenis_default.jpg'}" class="product-img w-full h-40 object-cover rounded cursor-pointer" onerror="this.onerror=null;this.src='tenis_default.jpg';" alt="${
+      }" data-full="${p.foto || 'tenis_default.jpg'}" class="product-img w-full aspect-[3/4] object-cover rounded cursor-pointer" onerror="this.onerror=null;this.src='tenis_default.jpg';" alt="${
         p.modelo
       }">
       <h3 class="mt-2 font-semibold">${p.marca} ${p.modelo}</h3>


### PR DESCRIPTION
## Summary
- maintain 3:4 aspect ratio for product photos in public and private galleries
- adjust skeleton loader placeholder to match new ratio

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68792afc0c3083259ff23ff22ecb8737