### PR TITLE
Add alert banner for public inventory updates

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -111,6 +111,13 @@
           onerror="this.onerror=null;this.src='https://placehold.co/1600x400/334155/e2e8f0?text=banner.jpg+no+encontrado';"
         />
         <div
+          id="publicInventoryBanner"
+          class="hidden bg-yellow-50 border-l-4 border-yellow-400 text-yellow-700 p-4 mt-4 rounded"
+        >
+          Inventario público desactualizado.
+          <a href="exportar.html" class="underline font-semibold">Actualizar</a>
+        </div>
+        <div
           class="mt-4 flex flex-col md:flex-row justify-between items-center"
         >
           <div class="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- add a hidden banner in **admin.html** to warn when the public inventory needs an update
- track pending public inventory updates in localStorage and show banner only to *Juan Alfredo Cuellar Piedra*
- show/hide banner when relevant actions occur instead of auto-exporting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d0e767a048325af84a6edacec6bee