### PR TITLE
Manual update workflow for inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,34 +43,16 @@ El script actualizará la colección `inventario` bajo `negocio-tenis/shared_dat
 
 ## Exportar Inventario para la sección pública
 
-El script `export-inventory` genera un archivo `inventory.json` con los productos disponibles. Esta memoria intermedia permite que la página pública funcione sin credenciales de Firebase.
+`inventory.json` funciona como caché para la galería pública. Cuando se detecte
+un movimiento en el inventario privado aparecerá un aviso dentro de la pestaña
+**Inventario**. El encargado debe seguir estos pasos:
 
-```bash
-npm run export-inventory -- path/to/serviceAccount.json
-```
+1. Abrir `exportar.html` y pulsar **Obtener inventario**.
+2. Descargar el archivo con **Descargar JSON**.
+3. Subir `inventory.json` al repositorio.
+4. Cerrar el aviso usando el botón «X».
 
-El archivo generado incluye las fechas de Firestore con las claves
-`seconds` y `nanoseconds` para asegurar que coincidan con la estructura que
-usa la aplicación web.
-
-En producción se puede generar automáticamente mediante una **Cloud Function**.
-Además, en la sección **Finanzas** existe el botón **Actualizar Inventario
-Público** que invoca dicha función manualmente.
-
-### Desplegar `exportInventory`
-
-Este repositorio incluye un ejemplo de Cloud Function en `functions/index.js`
-que genera el inventario y responde con los encabezados CORS necesarios. Para
-habilitarla debes desplegarla en tu proyecto de Firebase:
-
-```bash
-cd functions
-npm install
-firebase deploy --only functions:exportInventory
-```
-
-Al usarla desde `admin.html`, la respuesta incluirá `Access-Control-Allow-Origin`
-para evitar errores de CORS.
+Este procedimiento se repite cada vez que el inventario privado cambia.
 
 
 ### Configurar CORS en Firebase Storage

--- a/admin.html
+++ b/admin.html
@@ -112,10 +112,17 @@
         />
         <div
           id="publicInventoryBanner"
-          class="hidden bg-yellow-50 border-l-4 border-yellow-400 text-yellow-700 p-4 mt-4 rounded"
+          class="hidden relative bg-yellow-50 border-l-4 border-yellow-400 text-yellow-700 p-4 mt-4 rounded"
         >
-          Inventario público desactualizado.
-          <a href="exportar.html" class="underline font-semibold">Actualizar</a>
+          <button
+            id="closePublicInventoryBanner"
+            class="absolute top-1 right-2 text-xl leading-none"
+            aria-label="Cerrar"
+          >
+            &times;
+          </button>
+          <span>Inventario público desactualizado.</span>
+          <a href="exportar.html" class="underline font-semibold ml-1">Actualizar</a>
         </div>
         <div
           class="mt-4 flex flex-col md:flex-row justify-between items-center"
@@ -675,12 +682,6 @@
                     class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg"
                   >
                     <i class="fas fa-coins mr-2"></i>Abonos
-                  </button>
-                  <button
-                    id="updatePublicInventoryBtn"
-                    class="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-4 rounded-lg"
-                  >
-                    <i class="fas fa-sync-alt mr-2"></i>Actualizar Inventario Público
                   </button>
                   <button
                     id="backupDbBtn"

--- a/js/index.js
+++ b/js/index.js
@@ -1,9 +1,5 @@
 // Firebase Imports
-import {
-  firebaseConfig,
-  geminiApiKey,
-  inventoryExportEndpoint,
-} from './config.js';
+import { firebaseConfig, geminiApiKey } from './config.js';
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js';
 import {
   getAuth,
@@ -309,30 +305,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     reader.readAsText(file);
   };
 
-  const updatePublicInventory = async (silent = false) => {
-    try {
-      const res = await fetch(inventoryExportEndpoint, { method: 'POST' });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      clearPublicInventoryOutdated();
-      await checkPublicInventoryOutdated();
-      if (!silent) {
-        showAlert(
-          'Inventario Actualizado',
-          'Se generó el archivo público de inventario.',
-          'success',
-        );
-      }
-    } catch (error) {
-      console.error('Error updating public inventory:', error);
-      if (!silent) {
-        showAlert(
-          'Error',
-          'No se pudo actualizar el inventario público.',
-          'error',
-        );
-      }
-    }
-  };
 
   const fetchImageWithProxy = async (url) => {
     const attempt = async (u) => {
@@ -3082,8 +3054,8 @@ ${comprasHtml}
         exportArrayToCSV(allAbonos, 'abonos.csv'),
       );
     document
-      .getElementById('updatePublicInventoryBtn')
-      .addEventListener('click', updatePublicInventory);
+      .getElementById('closePublicInventoryBanner')
+      .addEventListener('click', clearPublicInventoryOutdated);
     document
       .getElementById('backupDbBtn')
       .addEventListener('click', backupDatabase);


### PR DESCRIPTION
## Summary
- simplify inventory update instructions in README
- add closable banner for outdated public inventory in `admin.html`
- remove automatic public inventory update button
- remove unused code and adjust banner logic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687eac0d85a483259505e99a9a4eb03d