### PR TITLE
Replace inventory banner with update button

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -111,20 +111,6 @@
           onerror="this.onerror=null;this.src='https://placehold.co/1600x400/334155/e2e8f0?text=banner.jpg+no+encontrado';"
         />
         <div
-          id="publicInventoryBanner"
-          class="hidden relative bg-yellow-50 border-l-4 border-yellow-400 text-yellow-700 p-4 mt-4 rounded"
-        >
-          <button
-            id="closePublicInventoryBanner"
-            class="absolute top-1 right-2 text-xl leading-none"
-            aria-label="Cerrar"
-          >
-            &times;
-          </button>
-          <span>Inventario público desactualizado.</span>
-          <a href="exportar.html" class="underline font-semibold ml-1">Actualizar</a>
-        </div>
-        <div
           class="mt-4 flex flex-col md:flex-row justify-between items-center"
         >
           <div class="flex items-center space-x-4">
@@ -184,10 +170,10 @@
           <div
             class="flex flex-col md:flex-row justify-between items-center gap-4"
           >
-            <div class="relative w-full md:w-1/2">
-              <span
-                class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-                ><i class="fas fa-search"></i
+          <div class="relative w-full md:w-1/2">
+            <span
+              class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+              ><i class="fas fa-search"></i
               ></span>
               <input
                 type="text"
@@ -317,13 +303,22 @@
                 <i class="fas fa-times-circle"></i>
               </button>
             </div>
+          <div class="flex gap-2">
             <button
               id="openInventarioModalBtn"
               class="w-full md:w-auto bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-5 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex-shrink-0"
             >
               <i class="fas fa-plus mr-2"></i>Agregar Producto
             </button>
+            <a
+              id="publicInventoryBanner"
+              href="exportar.html"
+              target="_blank"
+              class="hidden w-full md:w-auto bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-3 px-5 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 flex-shrink-0"
+              >Actualizar Inventario</a
+            >
           </div>
+        </div>
 
           <div
             class="bg-indigo-600 text-white p-4 rounded-xl shadow-lg flex justify-between items-center"

--- a/js/index.js
+++ b/js/index.js
@@ -3054,9 +3054,6 @@ ${comprasHtml}
         exportArrayToCSV(allAbonos, 'abonos.csv'),
       );
     document
-      .getElementById('closePublicInventoryBanner')
-      .addEventListener('click', clearPublicInventoryOutdated);
-    document
       .getElementById('backupDbBtn')
       .addEventListener('click', backupDatabase);
     document


### PR DESCRIPTION
## Summary
- remove inventory alert banner
- add button to update public inventory next to "Agregar Producto"
- remove unused event listener

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687eb0064e64832580bce63a31989b58