### PR TITLE
Enable infinite carousel

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,10 @@ export default [
         alert: 'readonly',
         pdfMake: 'readonly',
         htmlToPdfmake: 'readonly',
-        Image: 'readonly'
+        Image: 'readonly',
+        cancelAnimationFrame: 'readonly',
+        requestAnimationFrame: 'readonly',
+        getComputedStyle: 'readonly'
       }
     },
     rules: {}

--- a/index.html
+++ b/index.html
@@ -42,9 +42,8 @@
       }
       .carousel {
         display: flex;
-        overflow-x: auto;
+        overflow: hidden;
         gap: 1rem;
-        scroll-snap-type: x mandatory;
         padding-bottom: 1rem;
       }
       .carousel-item {

--- a/js/public.js
+++ b/js/public.js
@@ -76,6 +76,35 @@ function setupCarouselNav(containerId, itemCount) {
   }
 }
 
+const carouselLoops = {};
+
+function startInfiniteScroll(containerId, speed = 0.5) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  if (carouselLoops[containerId]) {
+    cancelAnimationFrame(carouselLoops[containerId]);
+  }
+  const gap = parseFloat(getComputedStyle(container).gap) || 0;
+  const step = speed;
+  const move = () => {
+    container.scrollLeft += step;
+    const first = container.firstElementChild;
+    if (first && container.scrollLeft >= first.offsetWidth + gap) {
+      container.appendChild(first);
+      container.scrollLeft -= first.offsetWidth + gap;
+    }
+    carouselLoops[containerId] = requestAnimationFrame(move);
+  };
+  move();
+  container.addEventListener('mouseenter', () => {
+    if (carouselLoops[containerId])
+      cancelAnimationFrame(carouselLoops[containerId]);
+  });
+  container.addEventListener('mouseleave', () => {
+    if (!carouselLoops[containerId]) move();
+  });
+}
+
 function renderCarousel(containerId, products) {
   const container = document.getElementById(containerId);
   if (!container) return;
@@ -98,6 +127,7 @@ function renderCarousel(containerId, products) {
     container.appendChild(card);
   });
   setupCarouselNav(containerId, products.length);
+  startInfiniteScroll(containerId);
 }
 
 function renderCarousels() {


### PR DESCRIPTION
## Summary
- animate product carousels so they loop endlessly
- hide carousel overflow to support smooth looping
- allow animation APIs in ESLint config

## Testing
- `npm install`
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687fd78ff5a083258078d29ffccb18e9