### PR TITLE
Enable drag scrolling and hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,9 +45,20 @@
         overflow: hidden;
         gap: 1rem;
         padding-bottom: 1rem;
+        cursor: grab;
       }
       .carousel-item {
         scroll-snap-align: center;
+      }
+      .dragging {
+        cursor: grabbing !important;
+      }
+      .product-img {
+        transition: transform 0.3s;
+      }
+      .carousel-item:hover .product-img {
+        transform: scale(1.3);
+        z-index: 10;
       }
       .carousel-wrapper {
         position: relative;

--- a/js/public.js
+++ b/js/public.js
@@ -111,8 +111,40 @@ function startInfiniteScroll(containerId, speed = 0.5) {
   move();
   container.addEventListener('mouseenter', stopLoop);
   container.addEventListener('mouseleave', startLoop);
-  container.addEventListener('touchstart', stopLoop);
+  container.addEventListener('touchstart', stopLoop, { passive: true });
   container.addEventListener('touchend', startLoop);
+  container.addEventListener('mousedown', stopLoop);
+  container.addEventListener('mouseup', startLoop);
+
+  let isDragging = false;
+  let startX = 0;
+  let startScroll = 0;
+
+  const pointerDown = (clientX) => {
+    isDragging = true;
+    startX = clientX;
+    startScroll = container.scrollLeft;
+    container.classList.add('dragging');
+  };
+
+  const pointerMove = (clientX) => {
+    if (!isDragging) return;
+    container.scrollLeft = startScroll - (clientX - startX);
+  };
+
+  const pointerUp = () => {
+    isDragging = false;
+    container.classList.remove('dragging');
+  };
+
+  container.addEventListener('mousedown', (e) => pointerDown(e.clientX));
+  container.addEventListener('mousemove', (e) => pointerMove(e.clientX));
+  container.addEventListener('mouseup', pointerUp);
+  container.addEventListener('mouseleave', pointerUp);
+  container.addEventListener('touchstart', (e) => pointerDown(e.touches[0].clientX), { passive: true });
+  container.addEventListener('touchmove', (e) => pointerMove(e.touches[0].clientX), { passive: true });
+  container.addEventListener('touchend', pointerUp);
+  container.addEventListener('touchcancel', pointerUp);
 }
 
 function renderCarousel(containerId, products) {


### PR DESCRIPTION
## Summary
- allow carousel drag scrolling with mouse or touch
- enlarge products on hover

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fe494b98083258766e02a6a31e0b5