### PR TITLE
Fix carousel scrolling on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,10 +42,12 @@
       }
       .carousel {
         display: flex;
-        overflow: hidden;
+        overflow-x: auto;
+        overflow-y: hidden;
         gap: 1rem;
         padding-bottom: 1rem;
         cursor: grab;
+        -webkit-overflow-scrolling: touch;
       }
       .carousel-item {
         scroll-snap-align: center;


### PR DESCRIPTION
## Summary
- allow horizontal scrolling of carousel on iOS by adjusting overflow
- keep scrollbar hidden and enable momentum scrolling

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fe86b93c083259ddd3c1f9e9adbd9