### PR TITLE
Add export page to generate inventory JSON from Firestore

### DIFF
--- a/exportar.html
+++ b/exportar.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Exportar inventario público</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        font-family: 'Inter', sans-serif;
+      }
+      #log {
+        max-height: 280px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body class="min-h-screen bg-slate-100 py-10">
+    <main class="mx-auto max-w-3xl rounded-2xl bg-white p-6 shadow-xl">
+      <header class="mb-6 space-y-2 text-center">
+        <h1 class="text-3xl font-semibold text-slate-800">
+          Exportar catálogo público
+        </h1>
+        <p class="text-sm text-slate-500">
+          Inicia sesión, consulta Firestore y descarga un
+          <code class="rounded bg-slate-100 px-2 py-1">inventory.json</code>
+          con los productos <strong>disponibles</strong> del catálogo.
+        </p>
+      </header>
+
+      <section
+        class="mb-6 flex flex-col gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div>
+          <p class="text-xs uppercase tracking-wide text-slate-500">
+            Estado de autenticación
+          </p>
+          <p id="auth-status" class="text-base font-medium text-slate-700">
+            Verifica tu identidad para continuar.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-3">
+          <button
+            id="login-btn"
+            class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-500"
+          >
+            Acceder con Google
+          </button>
+          <button
+            id="logout-btn"
+            class="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100"
+            hidden
+          >
+            Cerrar sesión
+          </button>
+        </div>
+      </section>
+
+      <section class="space-y-4">
+        <div
+          id="status-banner"
+          class="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600"
+        >
+          Conéctate para habilitar la exportación.
+        </div>
+        <button
+          id="export-btn"
+          class="w-full rounded-lg bg-emerald-600 px-4 py-3 text-center text-base font-semibold text-white shadow transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+          disabled
+        >
+          Generar archivo inventory.json
+        </button>
+        <div>
+          <p class="mb-2 text-xs uppercase tracking-wide text-slate-500">
+            Bitácora de exportación
+          </p>
+          <pre
+            id="log"
+            class="rounded-lg border border-slate-200 bg-slate-900 p-4 text-xs text-emerald-100"
+          ></pre>
+        </div>
+      </section>
+    </main>
+
+    <script type="module" src="./js/exportar.js"></script>
+  </body>
+</html>

--- a/js/exportar.js
+++ b/js/exportar.js
@@ -1,0 +1,169 @@
+import { firebaseConfig } from './config.js';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+} from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js';
+import {
+  initializeFirestore,
+  collection,
+  getDocs,
+  Timestamp,
+} from 'https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js';
+
+const app = initializeApp(firebaseConfig);
+const db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
+const auth = getAuth(app);
+const provider = new GoogleAuthProvider();
+
+const loginBtn = document.getElementById('login-btn');
+const logoutBtn = document.getElementById('logout-btn');
+const exportBtn = document.getElementById('export-btn');
+const statusBanner = document.getElementById('status-banner');
+const authStatus = document.getElementById('auth-status');
+const logEl = document.getElementById('log');
+
+const getSharedCollectionPath = (collectionName) =>
+  `negocio-tenis/shared_data/${collectionName}`;
+
+function appendLog(message) {
+  const timestamp = new Date().toLocaleTimeString('es-MX', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  logEl.textContent += `[${timestamp}] ${message}\n`;
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function setStatus(message, type = 'info') {
+  const colors = {
+    info: 'border-slate-200 bg-slate-50 text-slate-600',
+    success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    error: 'border-rose-200 bg-rose-50 text-rose-700',
+  };
+  statusBanner.className = `rounded-lg border p-4 text-sm ${colors[type] || colors.info}`;
+  statusBanner.textContent = message;
+}
+
+function serializeValue(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (value instanceof Timestamp) {
+    return {
+      seconds: value.seconds,
+      nanoseconds: value.nanoseconds,
+    };
+  }
+  if (Array.isArray(value)) {
+    return value.map(serializeValue);
+  }
+  return Object.keys(value)
+    .sort()
+    .reduce((acc, key) => {
+      const serialized = serializeValue(value[key]);
+      if (serialized !== undefined) {
+        acc[key] = serialized;
+      }
+      return acc;
+    }, {});
+}
+
+function serializeProduct(doc) {
+  const orderedKeys = Object.keys(doc).sort();
+  return orderedKeys.reduce((acc, key) => {
+    const value = serializeValue(doc[key]);
+    if (value !== undefined) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+}
+
+function downloadJsonFile(data, fileName) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+async function exportInventory() {
+  exportBtn.disabled = true;
+  setStatus('Consultando inventario en Firestore...', 'info');
+  appendLog('Solicitando documentos de la colección de inventario.');
+
+  try {
+    const snapshot = await getDocs(collection(db, getSharedCollectionPath('inventario')));
+    appendLog(`Colección recibida: ${snapshot.size} documentos totales.`);
+
+    const products = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+    const disponibles = products.filter((item) => (item.status || '').toLowerCase() === 'disponible');
+
+    appendLog(`Productos disponibles: ${disponibles.length}. Generando archivo...`);
+
+    const plainProducts = disponibles
+      .map(serializeProduct)
+      .sort((a, b) => (a.id || '').localeCompare(b.id || ''));
+
+    downloadJsonFile(plainProducts, 'inventory.json');
+    setStatus('Archivo inventory.json generado correctamente.', 'success');
+    appendLog('Descarga iniciada. Reemplaza el archivo en el repositorio para publicar los cambios.');
+  } catch (error) {
+    console.error('Error al exportar inventario', error);
+    setStatus('Ocurrió un error al exportar el inventario. Revisa la consola.', 'error');
+    appendLog(`Error: ${error.message}`);
+  } finally {
+    exportBtn.disabled = false;
+  }
+}
+
+loginBtn.addEventListener('click', async () => {
+  try {
+    setStatus('Autenticando con Google...', 'info');
+    await signInWithPopup(auth, provider);
+  } catch (error) {
+    console.error('Error al iniciar sesión', error);
+    setStatus('No se pudo iniciar sesión. Intenta nuevamente.', 'error');
+    appendLog(`Fallo en autenticación: ${error.message}`);
+  }
+});
+
+logoutBtn.addEventListener('click', async () => {
+  try {
+    await signOut(auth);
+    appendLog('Sesión cerrada.');
+  } catch (error) {
+    console.error('Error al cerrar sesión', error);
+    appendLog(`Error al cerrar sesión: ${error.message}`);
+  }
+});
+
+exportBtn.addEventListener('click', exportInventory);
+
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    authStatus.textContent = `${user.displayName || user.email}`;
+    loginBtn.hidden = true;
+    logoutBtn.hidden = false;
+    exportBtn.disabled = false;
+    setStatus('Autenticación completada. Puedes generar el archivo cuando gustes.', 'success');
+    appendLog('Autenticado correctamente.');
+  } else {
+    authStatus.textContent = 'Verifica tu identidad para continuar.';
+    loginBtn.hidden = false;
+    logoutBtn.hidden = true;
+    exportBtn.disabled = true;
+    setStatus('Conéctate para habilitar la exportación.', 'info');
+  }
+});


### PR DESCRIPTION
## Summary
- add an exportar.html workflow with Google authentication controls to guide the inventory export
- implement js/exportar.js to fetch Firestore inventory, filter available products, and download an ordered inventory.json file

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca01758f8c8325b44ef6bef5a1785a